### PR TITLE
skip if not a file

### DIFF
--- a/xtdbash
+++ b/xtdbash
@@ -108,8 +108,9 @@ function xtdbash_externals() {
   local c_file
 
   for c_file in ${l_home}/.bashrc.*; do
+    [ -f "${c_file}" ] || continue
     __xtdbash_verbose "loading external settings ${c_file}"
     # shellcheck disable=SC1090
-    . ${c_file}
+    . "${c_file}"
   done
 }


### PR DESCRIPTION
The glob expand to a string when nothing match the pattern resulting in:
```
$HOME/.bashrc.*: No such file or directory
```